### PR TITLE
Launch dfu util fix

### DIFF
--- a/app/device/labtool/labtooldevicecommthread.cpp
+++ b/app/device/labtool/labtooldevicecommthread.cpp
@@ -235,40 +235,45 @@ void LabToolDeviceCommThread::runDFU()
 
     QStringList arguments;
     arguments << "-R" << "-d 1fc9:000c" << "-D" << mPreparedImage;
-    //mDFUProcess->setWorkingDirectory("../tools/dfu-util-0.7-binaries/win32-mingw32/");
 
-    QProcess* m_DFUProcess = new QProcess();
-    m_DFUProcess->start(program, arguments);
-    if (m_DFUProcess->waitForFinished())
+    QProcess DFUProcess;
+    // DFUProcess.setWorkingDirectory("../tools/dfu-util-0.7-binaries/win32-mingw32/");
+    DFUProcess.start(program, arguments);
+    if (!DFUProcess.waitForStarted())
+    {
+        qDebug() << "DFU program \"" << program << "\" failed to start";
+        return;
+    }
+
+    if (DFUProcess.waitForFinished())
     {
 //        qDebug("DFU program finished");
 
-//        switch(m_DFUProcess->exitStatus()) {
+//        switch(DFUProcess.exitStatus()) {
 //        case QProcess::NormalExit: qDebug("exitStatus() = QProcess::NormalExit"); break;
 //        case QProcess::CrashExit:  qDebug("exitStatus() = QProcess::CrashExit"); break;
-//        default:                   qDebug("exitStatus() = unknown code %d", m_DFUProcess->exitStatus()); break;
+//        default:                   qDebug("exitStatus() = unknown code %d", DFUProcess.exitStatus()); break;
 //        }
 
-//        switch(m_DFUProcess->error()) {
+//        switch(DFUProcess.error()) {
 //        case QProcess::FailedToStart: qDebug("error() = QProcess::FailedToStart"); break;
 //        case QProcess::Crashed:       qDebug("error() = QProcess::Crashed"); break;
 //        case QProcess::Timedout:      qDebug("error() = QProcess::Timedout"); break;
 //        case QProcess::WriteError:    qDebug("error() = QProcess::WriteError"); break;
 //        case QProcess::ReadError:     qDebug("error() = QProcess::ReadError"); break;
 //        case QProcess::UnknownError:  qDebug("error() = QProcess::UnknownError"); break;
-//        default:                      qDebug("error() = unknown code %d", m_DFUProcess->error()); break;
+//        default:                      qDebug("error() = unknown code %d", DFUProcess.error()); break;
 //        }
 
-//        qDebug("exitCode() = %d", m_DFUProcess->exitCode());
+//        qDebug("exitCode() = %d", DFUProcess.exitCode());
 
-//        qDebug("readAllStandardError(): -->%s<--", m_DFUProcess->readAllStandardError().constData());
-//        qDebug("readAllStandardOutput(): -->%s<--", m_DFUProcess->readAllStandardOutput().constData());
+//        qDebug("readAllStandardError(): -->%s<--", DFUProcess.readAllStandardError().constData());
+//        qDebug("readAllStandardOutput(): -->%s<--", DFUProcess.readAllStandardOutput().constData());
     }
     else
     {
         qDebug("DFU program timed out waiting to finish");
     }
-    delete m_DFUProcess;
 }
 
 /*!


### PR DESCRIPTION
The first patch avoids zombie processes if dfu-tool isn't executable.  Otherwise leaving LabTool running with the hardware disconnected (I do that to stare at the waveforms) will eventually "fork-bomb" POSIX systems by exhausting the number of processes a user is allowed to have.

See https://bugreports.qt-project.org/browse/QTBUG-5990 for background. Qt has this bug where if the executable passed to QProcess.start() somehow fails to execute, it could leave zombie processes around even if the user calls WaitForStarted() and WaitForFinished() correctly. This patch works around a common source of this bug by checking the permission of the "dfu-util" executable before attempting to execute it.

The second patch in the series makes the path handling in LabToolDeviceCommThread::prepareDfuImage() more consistant with ::runDFU() and allows launching LabTool via "./app/LabTool", i.e. from one directory level up.

The third patch is a minor clean up. From the QProcess state machine design it's more correct to always call ::WaitForStarted() and only call ::WaitForFinished() if the former succeeds. This patch also make "DFUProcess" a local variable instead of a pointer to heap allocated storage to make forgetting to call delete on error paths impossible.
