### PR TITLE
Replaced QLineEdit Widgets in Calibration Wizard with QDoubleSpinbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ LabTool.pro.user
 # Qt Shadow Build directories (different for Qt4 and Qt5)
 LabTool-build-desktop-Qt_4_*
 build-LabTool-Desktop_Qt_5_*
+build-LabTool-Desktop_Qt5*
 
 # uVision output
 fw/program/uVision/Internal_SRAM/

--- a/app/device/labtool/labtoolcalibrationwizardanalogin.cpp
+++ b/app/device/labtool/labtoolcalibrationwizardanalogin.cpp
@@ -104,6 +104,8 @@ bool LabToolCalibrationWizardAnalogIn::isComplete() const
 */
 void LabToolCalibrationWizardAnalogIn::initializePage()
 {
+
+    // FIXME: Getting doubles from a QVariant might result in rounding errors.
     mA0[0] = field("a0LowLevel").toDouble();
     mA0[1] = field("a0MiddleLevel").toDouble();
     mA0[2] = field("a0HighLevel").toDouble();

--- a/app/device/labtool/labtoolcalibrationwizardanalogout.cpp
+++ b/app/device/labtool/labtoolcalibrationwizardanalogout.cpp
@@ -60,30 +60,30 @@ LabToolCalibrationWizardAnalogOut::LabToolCalibrationWizardAnalogOut(QWidget *pa
     // all Spinners are deactivated by default. Will be activated row by row by
     // nextValueClicked Slot.
     mSpinnerLowA0 = new QDoubleSpinBox();
-    mSpinnerLowA0->setDecimals(2);
+    mSpinnerLowA0->setDecimals(SPINNER_DECIMALS);
     mSpinnerLowA0->setRange(2.5, 3.0);
     mSpinnerLowA0->setValue(2.75);
-    mSpinnerLowA0->setSingleStep(0.01);
+    mSpinnerLowA0->setSingleStep(SPINNER_SINGLE_STEP);
     mSpinnerLowA0->setSuffix(mSpinnerSuffix);
     mSpinnerLowA0->setDisabled(true);
     registerField("a0LowLevel", mSpinnerLowA0, "value", "valueChanged");
     formLayoutA0->addRow(tr("Low level (about 2.75V)"), mSpinnerLowA0);
 
     mSpinnerMiddleA0 = new QDoubleSpinBox();
-    mSpinnerMiddleA0->setDecimals(2);
+    mSpinnerMiddleA0->setDecimals(SPINNER_DECIMALS);
     mSpinnerMiddleA0->setRange(-0.5, 0.5);
     mSpinnerMiddleA0->setValue(0);
-    mSpinnerMiddleA0->setSingleStep(0.01);
+    mSpinnerMiddleA0->setSingleStep(SPINNER_SINGLE_STEP);
     mSpinnerMiddleA0->setSuffix(mSpinnerSuffix);
     mSpinnerMiddleA0->setDisabled(true);
     registerField("a0MiddleLevel", mSpinnerMiddleA0, "value", "valueChanged");
     formLayoutA0->addRow(tr("Middle level (about 0V)"), mSpinnerMiddleA0);
 
     mSpinnerHighA0 = new QDoubleSpinBox();
-    mSpinnerHighA0->setDecimals(2);
+    mSpinnerHighA0->setDecimals(SPINNER_DECIMALS);
     mSpinnerHighA0->setRange(-3.0, -2.5);
     mSpinnerHighA0->setValue(-2.75);
-    mSpinnerHighA0->setSingleStep(0.01);
+    mSpinnerHighA0->setSingleStep(SPINNER_SINGLE_STEP);
     mSpinnerHighA0->setSuffix(mSpinnerSuffix);
     mSpinnerHighA0->setDisabled(true);
     registerField("a0HighLevel", mSpinnerHighA0, "value", "valueChanged");
@@ -95,30 +95,30 @@ LabToolCalibrationWizardAnalogOut::LabToolCalibrationWizardAnalogOut(QWidget *pa
     QGroupBox* groupBoxA1 = new QGroupBox(tr("Settings for AOUT_1"));
 
     mSpinnerLowA1 = new QDoubleSpinBox();
-    mSpinnerLowA1->setDecimals(2);
+    mSpinnerLowA1->setDecimals(SPINNER_DECIMALS);
     mSpinnerLowA1->setRange(2.5, 3.0);
     mSpinnerLowA1->setValue(2.75);
-    mSpinnerLowA1->setSingleStep(0.01);
+    mSpinnerLowA1->setSingleStep(SPINNER_SINGLE_STEP);
     mSpinnerLowA1->setSuffix(mSpinnerSuffix);
     mSpinnerLowA1->setDisabled(true);
     registerField("a1LowLevel", mSpinnerLowA1, "value", "valueChanged");
     formLayoutA1->addRow(tr("Low level (about 2.75V)"), mSpinnerLowA1);
 
     mSpinnerMiddleA1 = new QDoubleSpinBox();
-    mSpinnerMiddleA1->setDecimals(2);
+    mSpinnerMiddleA1->setDecimals(SPINNER_DECIMALS);
     mSpinnerMiddleA1->setRange(-0.5, 0.5);
     mSpinnerMiddleA1->setValue(0);
-    mSpinnerMiddleA1->setSingleStep(0.01);
+    mSpinnerMiddleA1->setSingleStep(SPINNER_SINGLE_STEP);
     mSpinnerMiddleA1->setSuffix(mSpinnerSuffix);
     mSpinnerMiddleA1->setDisabled(true);
     registerField("a1MiddleLevel", mSpinnerMiddleA1, "value", "valueChanged");
     formLayoutA1->addRow(tr("Middle level (about 0V)"), mSpinnerMiddleA1);
 
     mSpinnerHighA1 = new QDoubleSpinBox();
-    mSpinnerHighA1->setDecimals(2);
+    mSpinnerHighA1->setDecimals(SPINNER_DECIMALS);
     mSpinnerHighA1->setRange(-3.0, -2.5);
     mSpinnerHighA1->setValue(-2.75);
-    mSpinnerHighA1->setSingleStep(0.01);
+    mSpinnerHighA1->setSingleStep(SPINNER_SINGLE_STEP);
     mSpinnerHighA1->setSuffix(mSpinnerSuffix);
     mSpinnerHighA1->setDisabled(true);
     registerField("a1HighLevel", mSpinnerHighA1, "value", "valueChanged");
@@ -172,6 +172,7 @@ void LabToolCalibrationWizardAnalogOut::setVisible(bool visible)
     if (visible) {
         wizard()->setButtonText(QWizard::CustomButton1, tr("Next &Value"));
         wizard()->setOption(QWizard::HaveCustomButton1, true);
+        wizard()->adjustSize();
         connect(wizard(), SIGNAL(customButtonClicked(int)),
                 this, SLOT(nextValueClicked()));
     } else {
@@ -200,12 +201,7 @@ bool LabToolCalibrationWizardAnalogOut::isComplete() const
 */
 void LabToolCalibrationWizardAnalogOut::initializePage()
 {
-//    mLineEditLowA0->setText("2.73");
-//    mLineEditMiddleA0->setText("-0.023");
-//    mLineEditHighA0->setText("-2.771");
-//    mLineEditLowA1->setText("2.723");
-//    mLineEditMiddleA1->setText("-0.034");
-//    mLineEditHighA1->setText("-2.797");
+
 }
 
 /*!

--- a/app/device/labtool/labtoolcalibrationwizardanalogout.cpp
+++ b/app/device/labtool/labtoolcalibrationwizardanalogout.cpp
@@ -55,42 +55,74 @@ LabToolCalibrationWizardAnalogOut::LabToolCalibrationWizardAnalogOut(QWidget *pa
     QFormLayout* formLayoutA0 = new QFormLayout();
     QGroupBox* groupBoxA0 = new QGroupBox(tr("Settings for AOUT_0"));
 
-    mValidator.setRange(-5.0, 5.0, 5);
+    mSpinnerSuffix = " V";
 
-    mLineEditLowA0 = new QLineEdit();
-    mLineEditLowA0->setValidator(&mValidator);
-    registerField("a0LowLevel*", mLineEditLowA0);
-    formLayoutA0->addRow(tr("Low level (about 2.75V)"), mLineEditLowA0);
+    // all Spinners are deactivated by default. Will be activated row by row by
+    // nextValueClicked Slot.
+    mSpinnerLowA0 = new QDoubleSpinBox();
+    mSpinnerLowA0->setDecimals(2);
+    mSpinnerLowA0->setRange(2.5, 3.0);
+    mSpinnerLowA0->setValue(2.75);
+    mSpinnerLowA0->setSingleStep(0.01);
+    mSpinnerLowA0->setSuffix(mSpinnerSuffix);
+    mSpinnerLowA0->setDisabled(true);
+    registerField("a0LowLevel", mSpinnerLowA0, "value", "valueChanged");
+    formLayoutA0->addRow(tr("Low level (about 2.75V)"), mSpinnerLowA0);
 
-    mLineEditMiddleA0 = new QLineEdit();
-    mLineEditMiddleA0->setValidator(&mValidator);
-    registerField("a0MiddleLevel*", mLineEditMiddleA0);
-    formLayoutA0->addRow(tr("Middle level (about 0V)"), mLineEditMiddleA0);
+    mSpinnerMiddleA0 = new QDoubleSpinBox();
+    mSpinnerMiddleA0->setDecimals(2);
+    mSpinnerMiddleA0->setRange(-0.5, 0.5);
+    mSpinnerMiddleA0->setValue(0);
+    mSpinnerMiddleA0->setSingleStep(0.01);
+    mSpinnerMiddleA0->setSuffix(mSpinnerSuffix);
+    mSpinnerMiddleA0->setDisabled(true);
+    registerField("a0MiddleLevel", mSpinnerMiddleA0, "value", "valueChanged");
+    formLayoutA0->addRow(tr("Middle level (about 0V)"), mSpinnerMiddleA0);
 
-    mLineEditHighA0 = new QLineEdit();
-    mLineEditHighA0->setValidator(&mValidator);
-    registerField("a0HighLevel*", mLineEditHighA0);
-    formLayoutA0->addRow(tr("High level (about -2.75V)"), mLineEditHighA0);
+    mSpinnerHighA0 = new QDoubleSpinBox();
+    mSpinnerHighA0->setDecimals(2);
+    mSpinnerHighA0->setRange(-3.0, -2.5);
+    mSpinnerHighA0->setValue(-2.75);
+    mSpinnerHighA0->setSingleStep(0.01);
+    mSpinnerHighA0->setSuffix(mSpinnerSuffix);
+    mSpinnerHighA0->setDisabled(true);
+    registerField("a0HighLevel", mSpinnerHighA0, "value", "valueChanged");
+    formLayoutA0->addRow(tr("High level (about -2.75V)"), mSpinnerHighA0);
 
     groupBoxA0->setLayout(formLayoutA0);
 
     QFormLayout* formLayoutA1 = new QFormLayout();
     QGroupBox* groupBoxA1 = new QGroupBox(tr("Settings for AOUT_1"));
 
-    mLineEditLowA1 = new QLineEdit();
-    mLineEditLowA1->setValidator(&mValidator);
-    registerField("a1LowLevel*", mLineEditLowA1);
-    formLayoutA1->addRow(tr("Low level (about 2.75V)"), mLineEditLowA1);
+    mSpinnerLowA1 = new QDoubleSpinBox();
+    mSpinnerLowA1->setDecimals(2);
+    mSpinnerLowA1->setRange(2.5, 3.0);
+    mSpinnerLowA1->setValue(2.75);
+    mSpinnerLowA1->setSingleStep(0.01);
+    mSpinnerLowA1->setSuffix(mSpinnerSuffix);
+    mSpinnerLowA1->setDisabled(true);
+    registerField("a1LowLevel", mSpinnerLowA1, "value", "valueChanged");
+    formLayoutA1->addRow(tr("Low level (about 2.75V)"), mSpinnerLowA1);
 
-    mLineEditMiddleA1 = new QLineEdit();
-    mLineEditMiddleA1->setValidator(&mValidator);
-    registerField("a1MiddleLevel*", mLineEditMiddleA1);
-    formLayoutA1->addRow(tr("Middle level (about 0V)"), mLineEditMiddleA1);
+    mSpinnerMiddleA1 = new QDoubleSpinBox();
+    mSpinnerMiddleA1->setDecimals(2);
+    mSpinnerMiddleA1->setRange(-0.5, 0.5);
+    mSpinnerMiddleA1->setValue(0);
+    mSpinnerMiddleA1->setSingleStep(0.01);
+    mSpinnerMiddleA1->setSuffix(mSpinnerSuffix);
+    mSpinnerMiddleA1->setDisabled(true);
+    registerField("a1MiddleLevel", mSpinnerMiddleA1, "value", "valueChanged");
+    formLayoutA1->addRow(tr("Middle level (about 0V)"), mSpinnerMiddleA1);
 
-    mLineEditHighA1 = new QLineEdit();
-    mLineEditHighA1->setValidator(&mValidator);
-    registerField("a1HighLevel*", mLineEditHighA1);
-    formLayoutA1->addRow(tr("High level (about -2.75V)"), mLineEditHighA1);
+    mSpinnerHighA1 = new QDoubleSpinBox();
+    mSpinnerHighA1->setDecimals(2);
+    mSpinnerHighA1->setRange(-3.0, -2.5);
+    mSpinnerHighA1->setValue(-2.75);
+    mSpinnerHighA1->setSingleStep(0.01);
+    mSpinnerHighA1->setSuffix(mSpinnerSuffix);
+    mSpinnerHighA1->setDisabled(true);
+    registerField("a1HighLevel", mSpinnerHighA1, "value", "valueChanged");
+    formLayoutA1->addRow(tr("High level (about -2.75V)"), mSpinnerHighA1);
 
     groupBoxA1->setLayout(formLayoutA1);
 
@@ -107,6 +139,8 @@ LabToolCalibrationWizardAnalogOut::LabToolCalibrationWizardAnalogOut(QWidget *pa
     setLayout(layout);
 
     mCurrentLevel = HIGH;
+
+    mOneValueCycle = false;
 }
 
 /*!
@@ -148,6 +182,14 @@ void LabToolCalibrationWizardAnalogOut::setVisible(bool visible)
 }
 
 /*!
+ * \brief Validate the Next Button of the Wizard Page
+ */
+bool LabToolCalibrationWizardAnalogOut::isComplete() const
+{
+    return (mOneValueCycle == true) ? true : false;
+}
+
+/*!
     Overrides the QWizardPage::initializePage() function to fill in any default values.
 
     If any default values should be entered (e.g. the old calibrations
@@ -185,18 +227,41 @@ void LabToolCalibrationWizardAnalogOut::nextValueClicked()
     switch (mCurrentLevel)
     {
     case LOW:
+        mSpinnerMiddleA0->setDisabled(false);
+        mSpinnerMiddleA1->setDisabled(false);
+
+        mSpinnerLowA0->setDisabled(true);
+        mSpinnerLowA1->setDisabled(true);
+
         mCurrentLevel = MIDDLE;
         break;
     case MIDDLE:
+        mSpinnerHighA0->setDisabled(false);
+        mSpinnerHighA1->setDisabled(false);
+
+        mSpinnerMiddleA0->setDisabled(true);
+        mSpinnerMiddleA1->setDisabled(true);
+
+        mOneValueCycle = true;
         mCurrentLevel = HIGH;
         break;
     case HIGH:
-    default:
+        mSpinnerLowA0->setDisabled(false);
+        mSpinnerLowA1->setDisabled(false);
+
+        mSpinnerHighA0->setDisabled(true);
+        mSpinnerHighA1->setDisabled(true);
+
         mCurrentLevel = LOW;
+        break;
+    default:
         break;
     }
 
     comm->calibrateAnalogOut(mCurrentLevel);
+
+    if(mOneValueCycle)
+        emit completeChanged();
 }
 
 /*!
@@ -240,3 +305,4 @@ void LabToolCalibrationWizardAnalogOut::handleCalibrationSuccess(LabToolCalibrat
         break;
     }
 }
+

--- a/app/device/labtool/labtoolcalibrationwizardanalogout.h
+++ b/app/device/labtool/labtoolcalibrationwizardanalogout.h
@@ -18,6 +18,7 @@
 
 #include <QWizardPage>
 #include <QLabel>
+#include <QDoubleSpinBox>
 #include <QLineEdit>
 #include <QDoubleValidator>
 
@@ -27,15 +28,17 @@ class LabToolCalibrationWizardAnalogOut : public QWizardPage
 {
     Q_OBJECT
 public:
-    explicit LabToolCalibrationWizardAnalogOut(QWidget *parent = 0);
-
-    void setVisible(bool visible);
-
     enum Level {
         LOW    = 256,
         MIDDLE = 512,
         HIGH   = 768
     };
+
+    explicit LabToolCalibrationWizardAnalogOut(QWidget *parent = 0);
+
+    // QWizardPage interface
+    void setVisible(bool visible);
+    bool isComplete() const;
 
 protected:
     void initializePage();
@@ -54,17 +57,19 @@ private:
     QLabel *mLabel;
     QLabel *mLabelCurrentOutput;
 
-    QLineEdit *mLineEditLowA0;
-    QLineEdit *mLineEditMiddleA0;
-    QLineEdit *mLineEditHighA0;
+    QString mSpinnerSuffix;
 
-    QLineEdit *mLineEditLowA1;
-    QLineEdit *mLineEditMiddleA1;
-    QLineEdit *mLineEditHighA1;
+    QDoubleSpinBox *mSpinnerLowA0;
+    QDoubleSpinBox *mSpinnerMiddleA0;
+    QDoubleSpinBox *mSpinnerHighA0;
 
-    QDoubleValidator mValidator;
+    QDoubleSpinBox *mSpinnerLowA1;
+    QDoubleSpinBox *mSpinnerMiddleA1;
+    QDoubleSpinBox *mSpinnerHighA1;
 
     Level mCurrentLevel;
+    bool mOneValueCycle;
+
 };
 
 #endif // LABTOOLCALIBRATIONWIZARDANALOGOUT_H

--- a/app/device/labtool/labtoolcalibrationwizardanalogout.h
+++ b/app/device/labtool/labtoolcalibrationwizardanalogout.h
@@ -24,6 +24,9 @@
 
 #include "labtooldevicecomm.h"
 
+#define SPINNER_DECIMALS 3
+#define SPINNER_SINGLE_STEP 0.001
+
 class LabToolCalibrationWizardAnalogOut : public QWizardPage
 {
     Q_OBJECT


### PR DESCRIPTION
Hi,

I had problems calibrating my LabTool. I am using comma as decimal separator. I was able to enter Data into the Calibreation Wizard but the calibration result was hilarious. I changed the decimal separator to dot and suddenly everything worked out fine. Instead of fiddling with QlineEdit Widgets I decided to replace them with QDoubleSpinboxes. They have their own validator and one can set the Range individually. And of course no more problems with different decimal separators. 

I also added some logic to the Next value Button. At first all Spinboxes are disabled.
![calibration1](https://cloud.githubusercontent.com/assets/2805076/8443239/53b5f660-1f85-11e5-8170-69eccfc518bf.jpg)


Whenever you click on Next Value the corresponding row of Spinboxes will be activated. I think this should reduce confusions. 
![calibration2](https://cloud.githubusercontent.com/assets/2805076/8443251/6a12431e-1f85-11e5-987d-838111e56ddc.png)



I also added reasonable default values. Maximum deviation for each value is +/- 0.25V. I think this should be enough.

Thanks for this great application. I might start implementing some more things like additional signal analysers. Are you currently working on something like that?

Best Regards
Christian 
