### PR TITLE
added std:: to isfinite() and nan() to fix compile errors on g++ 4.9

### DIFF
--- a/app/device/labtool/labtoolcalibrationdata.cpp
+++ b/app/device/labtool/labtoolcalibrationdata.cpp
@@ -57,14 +57,15 @@ LabToolCalibrationData::LabToolCalibrationData(const quint8 *data)
 
             if (mReasonableData)
             {
-                if (!std::isfinite(mCalibA[ch][i]) || std::isnan(mCalibA[ch][i])) {
+                if (isInfiniteOrNan(mCalibA[ch][i]))
+                {
                     mReasonableData = false;
                 }
                 else if ((mCalibA[ch][i] < -1000) || (mCalibA[ch][i] > 1000))
                 {
                     mReasonableData = false;
                 }
-                else if (!std::isfinite(mCalibB[ch][i]) || std::isnan(mCalibB[ch][i]))
+                else if (isInfiniteOrNan(mCalibA[ch][i]))
                 {
                     mReasonableData = false;
                 }
@@ -129,6 +130,23 @@ void LabToolCalibrationData::printCalibrationInfo()
     qDebug(" 2000mV  %10.7f %10.7f  %10.7f %10.7f", mCalibA[0][i], mCalibB[0][i], mCalibA[1][i], mCalibB[1][i]);i++;
     qDebug(" 5000mV  %10.7f %10.7f  %10.7f %10.7f", mCalibA[0][i], mCalibB[0][i], mCalibA[1][i], mCalibB[1][i]);i++;
 }
+
+bool LabToolCalibrationData::isInfiniteOrNan(double d)
+{
+    // Check whether the compiler is c++11 conformant.
+    // With c++11 the isfinite() and isnan() macros became functions.
+#if (__cplusplus == 201103L)
+    return !std::isfinite(d) || std::isnan(d);
+#else
+    return !isfinite(d) || isnan(d);
+#endif
+}
+
+/*!
+    \fn static bool LabToolCalibrationData::isInfiniteOrNan()
+
+    Returns true if \a d is INFINITE or NaN, false otherwise.
+*/
 
 /*!
     \fn static int LabToolCalibrationData::rawDataByteSize()

--- a/app/device/labtool/labtoolcalibrationdata.cpp
+++ b/app/device/labtool/labtoolcalibrationdata.cpp
@@ -57,14 +57,14 @@ LabToolCalibrationData::LabToolCalibrationData(const quint8 *data)
 
             if (mReasonableData)
             {
-                if (!isfinite(mCalibA[ch][i]) || isnan(mCalibA[ch][i])) {
+                if (!std::isfinite(mCalibA[ch][i]) || std::isnan(mCalibA[ch][i])) {
                     mReasonableData = false;
                 }
                 else if ((mCalibA[ch][i] < -1000) || (mCalibA[ch][i] > 1000))
                 {
                     mReasonableData = false;
                 }
-                else if (!isfinite(mCalibB[ch][i]) || isnan(mCalibB[ch][i]))
+                else if (!std::isfinite(mCalibB[ch][i]) || std::isnan(mCalibB[ch][i]))
                 {
                     mReasonableData = false;
                 }

--- a/app/device/labtool/labtoolcalibrationdata.h
+++ b/app/device/labtool/labtoolcalibrationdata.h
@@ -48,6 +48,9 @@ private:
     calib_result mRawResult;
     bool mReasonableData;
 
+private:
+    static bool isInfiniteOrNan(double d);
+
 public:
     LabToolCalibrationData(const quint8* data);
 


### PR DESCRIPTION
This is needed to compile on my system (Void Linux) with g++ 4.9 and Qt5.7.