### PR TITLE
Make the complete capture area obey the color scheme

### DIFF
--- a/app/capture/uiplot.cpp
+++ b/app/capture/uiplot.cpp
@@ -196,6 +196,11 @@ void UiPlot::paintEvent(QPaintEvent *event)
 
         painter.restore();
     }
+
+    // also update the palette
+    QPalette p = palette();
+    p.setColor(QPalette::Base, Configuration::instance().outsidePlotColor());
+    setPalette(p);
 }
 
 /*!

--- a/app/common/configuration.cpp
+++ b/app/common/configuration.cpp
@@ -325,7 +325,16 @@ void Configuration::setAnalogOutCableColor(int id, QColor &c)
 QColor Configuration::outsidePlotColor()
 {
     //return QColor(235, 235, 235);
-    return QColor(249, 249, 249);
+    //return QColor(249, 249, 249);
+
+    // Make outsidePlotColor() obey the color scheme while still providing some contrast.
+    // Note that the default black color is #000000, so .lighter(...) will effectively
+    // multiply with 0, which does nothing.
+    return mActiveColorScheme == COLOR_SCHEME_DARK ?
+                // workaround for .lighter(...)
+                QColor::fromHsv(mPlotBackgroundColor.hsvHue(), mPlotBackgroundColor.hsvSaturation(),
+                                mPlotBackgroundColor.value()+30) :
+                QColor(mPlotBackgroundColor).darker(105);
 }
 
 /*!


### PR DESCRIPTION
By making the complete capture area follow the color of the scheme, the dark scheme now avoids drawing bright white areas. At least for my OS-global dark theme the readability is greatly improved, because it is not drawing grey text on white background even in the dark scheme any more. Light theme still works, of course, I have just added some contrast to it and changed it to be based on mPlotBackgroundColor.